### PR TITLE
Fixed syntax error in teams

### DIFF
--- a/templates/teams/teams.html
+++ b/templates/teams/teams.html
@@ -118,7 +118,7 @@
             {% endif %}
             <select class="page-select">
               {% for page in range(1, teams.pages + 1) %}
-                <option {% if teams.page == page %} selected{% endif %}="selected{% endif %}">{{ page }}</option>
+                <option {% if teams.page == page %} selected="selected"{% endif %}>{{ page }}</option>
               {% endfor %}
             </select>
             {% if teams.next_num %}


### PR DESCRIPTION
Was getting an internal server error on selecting the teams page in ctfd due to an extra endif in the template.  This PR should fix it.  I didn't check to see if it is present anywhere else, but this fixes the internal server error.